### PR TITLE
Modified searchFilter to scope exclusion to public search only.

### DIFF
--- a/search-exclude.php
+++ b/search-exclude.php
@@ -118,8 +118,10 @@ class SearchExclude
 
     public function searchFilter($query)
     {
-        if ($query->is_search) {
-            $query->set('post__not_in', array_merge($query->get('post__not_in'), $this->getExcluded()));
+        if(!is_admin()) {
+            if ($query->is_search) {
+                $query->set('post__not_in', array_merge($query->get('post__not_in'), $this->getExcluded()));
+            }
         }
         return $query;
     }


### PR DESCRIPTION
Hi Roman,
In reference to the following:

https://wordpress.org/support/topic/scope-exclude-to-ignore-admin-searches?replies=2#post-5692569 

I have created a fork of your search exclude plugin and made the changes I mentioned in the post above on a new branch here. Please take a look and advise as needed. If you think it's worth adding to the official plugin I would be honored! :)

Cheers,
-WD 
