### PR TITLE
Update search-exclude.php

### DIFF
--- a/search-exclude.php
+++ b/search-exclude.php
@@ -119,7 +119,7 @@ class SearchExclude
 
     public function searchFilter($query)
     {
-        if (!is_admin() && $query->is_search) {
+        if ((!is_admin() || DOING_AJAX) && $query->is_search) {
             $query->set('post__not_in', array_merge($query->get('post__not_in'), $this->getExcluded()));
         }
         return $query;


### PR DESCRIPTION
The is_admin() also returns true when an Ajax-function is called. So themes querying a search using Ajax don't benefit from your plugin. This solves the problem, while at the same time disabling excludes when in the admin panel.
