### PR TITLE
Rename Gutenberg plugin to be clearer

### DIFF
--- a/packages/gutenberg/index.js
+++ b/packages/gutenberg/index.js
@@ -2,6 +2,6 @@ import { registerPlugin } from '@wordpress/plugins';
 import { Metabox } from './metabox';
 
 // Register the plugin
-registerPlugin('custom-sidebar-metabox', {
+registerPlugin('search-exclude-sidebar-metabox', {
 	render: Metabox,
 });


### PR DESCRIPTION
Renames the Gutenberg metabox plugin to `search-exclude-sidebar-metabox`. This makes error messages clearer and should help avoid namespace issues (plugin name should be unique).